### PR TITLE
OnEmptyBatchAsync() now returns Task.CompletedTask.

### DIFF
--- a/src/Serilog.Sinks.OpenObserve/Sinks/OpenObserve/Sink.cs
+++ b/src/Serilog.Sinks.OpenObserve/Sinks/OpenObserve/Sink.cs
@@ -30,7 +30,7 @@ public class Sink(HttpClient client) : IBatchedLogEventSink, IDisposable
 
     public Task OnEmptyBatchAsync()
     {
-        return EmitBatchAsync([]);
+        return Task.CompletedTask;
     }
 
     public void Dispose()


### PR DESCRIPTION
This simple fix prevents empty payloads from being sent.